### PR TITLE
ng build --prod navExpanded doesn't exist

### DIFF
--- a/skeleton/client/src/app/nav/nav.component.ts
+++ b/skeleton/client/src/app/nav/nav.component.ts
@@ -10,6 +10,7 @@ import {OnInit} from '@angular/core';
 export class NavComponent implements OnInit {
 
   applicationData: any;
+  navExpanded: boolean;
 
   constructor(private navService: NavService) { }
 


### PR DESCRIPTION
When running a prod build(ng build --prod) to get a dist folder I see  an error that navExpanded doesn't exist. This change seems to fix that.